### PR TITLE
Feat: Group commit frequency into time ranges and clamp days to repo age

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Git Visualizer
+
+A JavaScript based CLI tool to visualize the `git` directory.
+
+## Features:
+Adil bhai, features yaha likhen..
+


### PR DESCRIPTION
1. Added grouping of consecutive days with identical commit counts into a single time range (reduces noisy rows). Also used ACSII characters for better formatting
Before: YYYY-MM-DD | commits (one line per day)
After: YYYY-MM-DD - YYYY-MM-DD | commits number | total days in range (1 mean, no range)

2. Clamp requested --days to repository age; show "(trimmed)" indicator when reduced. (see in After screenshot)

See below screenshots:
**Before:**
<img width="770" height="927" alt="old-0" src="https://github.com/user-attachments/assets/efab0d92-0279-41a4-b7a5-29bf120739c2" />

**After:** 
<img width="688" height="509" alt="new-0" src="https://github.com/user-attachments/assets/4d6a14a0-363f-4bb1-98e8-cd248e354c91" />


Fun Fact: This is first PR of me (Saadullah Khan) :)
